### PR TITLE
SISRP-45460 - Remove eform Links from Student Resources Card for Law Students

### DIFF
--- a/app/models/campus_solutions/student_resources.rb
+++ b/app/models/campus_solutions/student_resources.rb
@@ -154,15 +154,15 @@ module CampusSolutions
     end
 
     def is_jd_llm_only?
-      ((current_academic_roles[:lawJdLlm] || current_academic_roles[:lawJdCdp]) && !current_academic_roles[:lawJspJsd] && !current_academic_roles[:grad])
+      ((current_academic_roles["lawJdLlm"] || current_academic_roles["lawJdCdp"]) && !current_academic_roles["lawJspJsd"] && !current_academic_roles["grad"])
     end
 
     def is_law_visiting?
-      current_academic_roles[:lawVisiting] && !current_academic_roles[:grad]
+      current_academic_roles["lawVisiting"] && !current_academic_roles["grad"]
     end
 
     def is_non_degree_seeking_summer_visitor?
-      historical_academic_roles[:summerVisitor] && !historical_academic_roles[:degreeSeeking]
+      historical_academic_roles["summerVisitor"] && !historical_academic_roles["degreeSeeking"]
     end
 
     def xml_filename

--- a/spec/models/campus_solutions/student_resources_spec.rb
+++ b/spec/models/campus_solutions/student_resources_spec.rb
@@ -23,40 +23,40 @@ describe CampusSolutions::StudentResources do
   end
   let(:current_academic_roles) do
     {
-      doctorScienceLaw: false,
-      fpf: false,
-      haasBusinessAdminMasters: false,
-      haasBusinessAdminPhD: false,
-      haasFullTimeMba: false,
-      haasEveningWeekendMba: false,
-      haasExecMba: false,
-      haasMastersFinEng: false,
-      haasMbaPublicHealth: false,
-      haasMbaJurisDoctor: false,
-      jurisSocialPolicyMasters: false,
-      jurisSocialPolicyPhC: false,
-      jurisSocialPolicyPhD: false,
-      ugrdUrbanStudies: false,
-      summerVisitor: false,
-      courseworkOnly: false,
-      lawJspJsd: false,
-      lawJdLlm: false,
-      masterOfLawsLlm: false,
-      lawVisiting: false,
-      lawJdCdp: false,
-      ugrd: false,
-      grad: false,
-      law: false,
-      concurrent: false,
-      lettersAndScience: false,
-      degreeSeeking: false,
-      ugrdNonDegree: false
+      "doctorScienceLaw" => false,
+      "fpf" => false,
+      "haasBusinessAdminMasters" => false,
+      "haasBusinessAdminPhD" => false,
+      "haasFullTimeMba" => false,
+      "haasEveningWeekendMba" => false,
+      "haasExecMba" => false,
+      "haasMastersFinEng" => false,
+      "haasMbaPublicHealth" => false,
+      "haasMbaJurisDoctor" => false,
+      "jurisSocialPolicyMasters" => false,
+      "jurisSocialPolicyPhC" => false,
+      "jurisSocialPolicyPhD" => false,
+      "ugrdUrbanStudies" => false,
+      "summerVisitor" => false,
+      "courseworkOnly" => false,
+      "lawJspJsd" => false,
+      "lawJdLlm" => false,
+      "masterOfLawsLlm" => false,
+      "lawVisiting" => false,
+      "lawJdCdp" => false,
+      "ugrd" => false,
+      "grad" => false,
+      "law" => false,
+      "concurrent" => false,
+      "lettersAndScience" => false,
+      "degreeSeeking" => false,
+      "ugrdNonDegree" => false
     }
   end
   let(:historical_academic_roles) do
     {
-      summerVisitor: false,
-      degreeSeeking: false
+      "summerVisitor" => false,
+      "degreeSeeking" => false
     }
   end
   let(:link_response) do
@@ -111,7 +111,7 @@ describe CampusSolutions::StudentResources do
 
   context 'as a visiting law student' do
     before do
-      current_academic_roles.merge!({lawVisiting: true})
+      current_academic_roles.merge!({"lawVisiting" => true})
       roles.merge!({student: true, law: true})
     end
     it 'returns the expected number of sections/links' do
@@ -125,7 +125,7 @@ describe CampusSolutions::StudentResources do
 
   context 'as a non-degree seeking summer visitor' do
     before do
-      historical_academic_roles.merge!({summerVisitor: true})
+      historical_academic_roles.merge!({"summerVisitor" => true})
       roles.merge!({student: true, undergrad: true})
     end
     it 'returns the expected number of sections/links' do


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-45460

`MyAcademics::MyAcademicRoles.new(@uid).get_feed` returns an object that mixes symbol and string keys, like so:
```
:feed => {
  :current => {
    "law" => true,
    "grad" => true
  }
}
```
This fixes the `CampusSolutions::StudentResources` model, which was previously using symbol keys for everything. I'm also going to open a JIRA ticket to symbolize all the keys for the object, as I'm sure this will lead to more bugs in the future if we leave the object keys as a mix of symbols and strings.