### PR TITLE
[CalCentral A] career_spec.rb

### DIFF
--- a/spec/models/edo_oracle/career_spec.rb
+++ b/spec/models/edo_oracle/career_spec.rb
@@ -42,7 +42,7 @@ describe EdoOracle::Career do
 
   describe '#get_cumulative_units' do
     subject { described_class.new({user_id: uid}).get_cumulative_units }
-    context 'user id 790833' do
+    context 'user id 790833 with 1 element, nil value for total_cumulative_law_units' do
       let(:uid) { 790833 }
       it 'returns the expected result' do
         expect(subject).to be
@@ -53,7 +53,7 @@ describe EdoOracle::Career do
       end
     end
 
-    context 'user id 300216' do
+    context 'user id 300216 with multiple elements, with non-nil values for total_cumulative_law_units' do
       let(:uid) {300216}
       it 'returns the expected result' do
       expect(subject).to be

--- a/spec/models/edo_oracle/career_spec.rb
+++ b/spec/models/edo_oracle/career_spec.rb
@@ -3,7 +3,7 @@ describe EdoOracle::Career do
   describe '#fetch' do
     subject { described_class.new({user_id: uid}).fetch }
 
-    context 'user id 790833' do
+    context 'when user has 2 values' do
       let(:uid) { 790833 }
       it 'returns the expected result' do
         expect(subject).to be
@@ -19,7 +19,7 @@ describe EdoOracle::Career do
       end
     end
 
-    context 'user id 300216' do
+    context 'when user has 3 values' do
       let(:uid) { 300216 }
       it 'returns the expected result' do
         expect(subject).to be
@@ -42,7 +42,7 @@ describe EdoOracle::Career do
 
   describe '#get_cumulative_units' do
     subject { described_class.new({user_id: uid}).get_cumulative_units }
-    context 'user id 790833 with 1 element, nil value for total_cumulative_law_units' do
+    context 'when user has single nil value for total_cumulative_law_units' do
       let(:uid) { 790833 }
       it 'returns the expected result' do
         expect(subject).to be
@@ -53,7 +53,7 @@ describe EdoOracle::Career do
       end
     end
 
-    context 'user id 300216 with multiple elements, with non-nil values for total_cumulative_law_units' do
+    context 'when user has multiple non-nil values for total_cumulative_law_units' do
       let(:uid) {300216}
       it 'returns the expected result' do
       expect(subject).to be

--- a/spec/models/edo_oracle/career_spec.rb
+++ b/spec/models/edo_oracle/career_spec.rb
@@ -2,18 +2,72 @@ describe EdoOracle::Career do
 
   describe '#fetch' do
     subject { described_class.new({user_id: uid}).fetch }
-    let(:uid) { 790833 }
-    it 'returns the expected result' do
+
+    context 'user id 790833' do
+      let(:uid) { 790833 }
+      it 'returns the expected result' do
+        expect(subject).to be
+        expect(subject.count).to be 2
+
+        expect(subject[0].count).to eq 10
+        expect(subject[0]).to have_keys(%w(acad_career program_status total_cumulative_units total_cumulative_law_units))
+        expect(subject[0]).to have_keys(%w(total_transfer_units transfer_units_adjustment ap_test_units ib_test_units alevel_test_units total_transfer_units_law))
+
+        expect(subject[1].count).to eq 10
+        expect(subject[1]).to have_keys(%w(acad_career program_status total_cumulative_units total_cumulative_law_units))
+        expect(subject[1]).to have_keys(%w(total_transfer_units transfer_units_adjustment ap_test_units ib_test_units alevel_test_units total_transfer_units_law))
+      end
+    end
+
+    context 'user id 300216' do
+      let(:uid) { 300216 }
+      it 'returns the expected result' do
+        expect(subject).to be
+        expect(subject.count).to be 3
+
+        expect(subject[0].count).to eq 10
+        expect(subject[0]).to have_keys(%w(acad_career program_status total_cumulative_units total_cumulative_law_units))
+        expect(subject[0]).to have_keys(%w(total_transfer_units transfer_units_adjustment ap_test_units ib_test_units alevel_test_units total_transfer_units_law))
+
+        expect(subject[1].count).to eq 10
+        expect(subject[1]).to have_keys(%w(acad_career program_status total_cumulative_units total_cumulative_law_units))
+        expect(subject[1]).to have_keys(%w(total_transfer_units transfer_units_adjustment ap_test_units ib_test_units alevel_test_units total_transfer_units_law))
+
+        expect(subject[2].count).to eq 10
+        expect(subject[2]).to have_keys(%w(acad_career program_status total_cumulative_units total_cumulative_law_units))
+        expect(subject[2]).to have_keys(%w(total_transfer_units transfer_units_adjustment ap_test_units ib_test_units alevel_test_units total_transfer_units_law))
+      end
+    end
+  end
+
+  describe '#get_cumulative_units' do
+    subject { described_class.new({user_id: uid}).get_cumulative_units }
+    context 'user id 790833' do
+      let(:uid) { 790833 }
+      it 'returns the expected result' do
+        expect(subject).to be
+        expect(subject.count).to be 1
+        expect(subject[0]).to have_keys(%w(acad_career program_status total_cumulative_units total_cumulative_law_units))
+        expect(subject[0]['total_cumulative_units']).to eq 2.0
+        expect(subject[0]['total_cumulative_law_units']).to be_nil
+      end
+    end
+
+    context 'user id 300216' do
+      let(:uid) {300216}
+      it 'returns the expected result' do
       expect(subject).to be
-      expect(subject.count).to be 2
-
-      expect(subject[0].count).to eq 10
-      expect(subject[0]).to have_keys(%w(acad_career program_status total_cumulative_units total_cumulative_law_units))
-      expect(subject[0]).to have_keys(%w(total_transfer_units transfer_units_adjustment ap_test_units ib_test_units alevel_test_units total_transfer_units_law))
-
-      expect(subject[1].count).to eq 10
-      expect(subject[1]).to have_keys(%w(acad_career program_status total_cumulative_units total_cumulative_law_units))
-      expect(subject[1]).to have_keys(%w(total_transfer_units transfer_units_adjustment ap_test_units ib_test_units alevel_test_units total_transfer_units_law))
+      expect(subject.count).to be 3
+      for i in 0..2
+        expect(subject[i]).to have_keys(%w(acad_career program_status total_cumulative_units total_cumulative_law_units))
+      end
+      expect(subject[0]['total_cumulative_units']).to eq 16.0
+      expect(subject[0]['total_cumulative_law_units']).to eq 0.0
+      expect(subject[1]['total_cumulative_units']).to eq 61.0
+      expect(subject[1]['total_cumulative_law_units']).to eq 46.0
+      expect(subject[2]['total_cumulative_units']).to eq 157.0
+      expect(subject[2]['total_cumulative_law_units']).to eq 0.0
+      end
     end
   end
 end


### PR DESCRIPTION
Tests added and improved by Rishab Srivastava and Samir Naqvi. CS 169, CalCentral A.

- Created two tests for `get_cumulative_units`, and check expected results for User IDs 300216, 790833
- Added one additional test for `fetch` by adding an additional User ID 300216
