### PR TITLE
[CalCentral A] account_roles_spec.rb

### DIFF
--- a/spec/models/canvas/account_roles_spec.rb
+++ b/spec/models/canvas/account_roles_spec.rb
@@ -48,4 +48,12 @@ describe Canvas::AccountRoles do
     end
   end
 
+  context 'when an invalid account' do
+    let(:account_id) {000000}
+    it 'does not have defined course roles' do
+      result = subject.defined_course_roles
+      expect(result).to eq([])
+    end
+  end
+
 end

--- a/spec/models/canvas/account_roles_spec.rb
+++ b/spec/models/canvas/account_roles_spec.rb
@@ -19,6 +19,10 @@ describe Canvas::AccountRoles do
   context 'when an academic department subaccount' do
     let(:account_id) {department_account_id}
     it_behaves_like 'a bCourses account'
+    it 'has defined course roles' do
+      result = subject.defined_course_roles
+      expect(result).not_to be_nil
+    end
     it 'has the extra official course roles' do
       result = subject.defined_course_roles
       labels = result.collect {|r| r['label']}
@@ -33,6 +37,10 @@ describe Canvas::AccountRoles do
   context 'when a project sites account' do
     let(:account_id) {project_account_id}
     it_behaves_like 'a bCourses account'
+    it 'has defined course roles' do
+      result = subject.defined_course_roles
+      expect(result).not_to be_nil
+    end
     it 'has the extra project site roles' do
       result = subject.defined_course_roles
       labels = result.collect {|r| r['label']}


### PR DESCRIPTION
- Added an intermediate test to check that the 'defined_course_roles' method returns an output when given a proper academic department sub-account or projects site account ID as input.
- Added a test to ensure proper handling of invalid student.

Tests added and improved by Srujay Korlakunta and Andrew Wan.