### PR TITLE
[CalCentral A] find_groups_spec.rb

### DIFF
--- a/spec/models/cal_groups/find_groups_spec.rb
+++ b/spec/models/cal_groups/find_groups_spec.rb
@@ -33,6 +33,15 @@ describe CalGroups::FindGroups do
     end
   end
 
+  shared_examples 'unexpected response' do
+    it 'raises a properly formatted error on group query' do
+      expect(name_available_response[:statusCode]).to eq 503
+    end
+    it 'returns an error on name query' do
+      expect { || find_group }.to raise_error(Errors::ProxyError){|error| expect(error.log_message).to eq 'Error response from CalGroups'}
+    end
+  end
+
   context 'using fake data feed' do
     let(:fake) { true }
 
@@ -49,15 +58,13 @@ describe CalGroups::FindGroups do
       include_examples 'group not found'
     end
 
-    context 'on unspecified failure' do
+    context 'on unsuccessful response' do
       before do
         proxy.override_json do |json|
           json['WsFindGroupsResults']['resultMetadata']['success'] = 'F'
         end
       end
-      it 'returns an error' do
-        expect(name_available_response[:statusCode]).to eq 503
-      end
+      include_examples 'unexpected response'
     end
   end
 end


### PR DESCRIPTION
Tests added and improved by Moses Kim. CS 169, CalCentral A.
- Created a test to check that the raised error for an unsuccessful CalGroups response is of the correct type (`Errors:ProxyError`) and log message
- Extracted test for error behavior into `'unexpected response'` shared example

Note: the `successful?(response) && response['WsFindGroupsResults']` condition of `find_groups.rb` (Line 22) may be redundant, as `successful?(response)` raises an error through `results_metadata` when `response['WsFindGroupsResults']` is `nil`. Another test for a successful but malformed response may be necessary.