### PR TITLE
SISRP-39356 - Updates HubEdos::Student to return academic levels based on latest term registrations

### DIFF
--- a/app/models/hub_edos/student.rb
+++ b/app/models/hub_edos/student.rb
@@ -5,13 +5,13 @@ module HubEdos
     end
 
     def max_terms_in_attendance
-      if statuses = student_data[:feed]['academicStatuses']
-        return statuses.collect {|s| s['termsInAttendance']}.sort.last
+      if student_academic_statuses
+        return student_academic_statuses.collect {|s| s['termsInAttendance']}.sort.last
       end
     end
 
     def student_academic_levels
-      current_term_registrations.collect {|registration| academic_level_description(registration) }
+      latest_term_registrations.collect {|registration| academic_level_description(registration) }
     end
 
     private
@@ -20,21 +20,33 @@ module HubEdos
       @student_data ||= HubEdos::V2::Student.new(user_id: @uid).get
     end
 
+    def student_registrations
+      student_data[:feed]['registrations']
+    end
+
+    def student_academic_statuses
+      student_data[:feed]['academicStatuses']
+    end
+
     def academic_level_description(registration)
       type_code = registration['academicCareer']['code'] == 'LAW' ? 'EOT' : 'BOT'
       level = registration['academicLevels'].find {|al| al['type']['code'] == type_code }
       level['level']['description']
     end
 
-    def current_term_registrations
-      @current_term_registrations ||= begin
-        current_term_id = Berkeley::Terms.fetch.current.campus_solutions_id
-        if registrations = student_data[:feed]['registrations']
-          registrations.select { |r| r['term']['id'] == current_term_id }
+    def latest_term_registrations
+      @latest_term_registrations ||= begin
+        if student_registrations
+          highest_term_id = highest_registrations_term_id
+          student_registrations.select { |reg| reg['term']['id'] == highest_term_id }
         else
           []
         end
       end
+    end
+
+    def highest_registrations_term_id
+      student_registrations.collect {|reg| reg['term'].try(:[], 'id') }.sort.last
     end
   end
 end

--- a/spec/models/hub_edos/student_spec.rb
+++ b/spec/models/hub_edos/student_spec.rb
@@ -46,78 +46,104 @@ describe HubEdos::Student do
         'academicLevels' => academic_levels
       }
     end
-    before { allow(subject).to receive(:current_term_registrations).and_return([registration]) }
+    before { allow(subject).to receive(:latest_term_registrations).and_return([registration]) }
     context 'when career code is not LAW' do
       let(:registration_academic_career_code) { 'UGRD' }
       it 'returns the beginning of term academic level description' do
-        expect(subject.instance_eval { academic_level_description(current_term_registrations[0]) }).to eq 'Beginning of Term Description'
+        expect(subject.instance_eval { academic_level_description(latest_term_registrations[0]) }).to eq 'Beginning of Term Description'
       end
     end
     context 'when career code is LAW' do
       let(:registration_academic_career_code) { 'LAW' }
       it 'returns the end of term academic level description' do
-        expect(subject.instance_eval { academic_level_description(current_term_registrations[0]) }).to eq 'End of Term Description'
+        expect(subject.instance_eval { academic_level_description(latest_term_registrations[0]) }).to eq 'End of Term Description'
       end
     end
   end
 
-  describe '#current_term_registrations' do
-    let(:student_feed) { {'registrations' => registrations_array} }
-    let(:current_term_id) { '2182' }
-    let(:registrations_array) do
+  describe '#latest_term_registrations' do
+    let(:student_registrations) do
       [
         {'term' => {'id' => '2182'}, 'academicCareer' => {'code' => 'UGRD'}},
         {'term' => {'id' => '2185'}, 'academicCareer' => {'code' => 'UGRD'}},
         {'term' => {'id' => '2188'}, 'academicCareer' => {'code' => 'UGRD'}},
       ]
     end
-    let(:berkeley_terms) do
-      current_term = double(:current_term, :campus_solutions_id => current_term_id)
-      double(:terms, :current => current_term)
-    end
+    let(:highest_registrations_term_id) { '2188' }
     before do
-      allow(subject).to receive(:student_data).and_return(student_api_response)
-      allow(Berkeley::Terms).to receive(:fetch).and_return(berkeley_terms)
-    end
-    context 'when registration is present for current term' do
-      let(:current_term_id) { '2182' }
-      it 'returns current term registration object' do
-        expect(subject.instance_eval { current_term_registrations[0]['term']['id'] }).to eq '2182'
-      end
+      allow(subject).to receive(:student_registrations).and_return(student_registrations)
+      allow(subject).to receive(:highest_registrations_term_id).and_return(highest_registrations_term_id)
     end
     context 'when no registrations in student data' do
-      let(:student_feed) { {} }
+      let(:student_registrations) { [] }
       it 'returns empty array' do
-        expect(subject.instance_eval { current_term_registrations }).to eq []
+        expect(subject.instance_eval { latest_term_registrations }).to eq []
       end
     end
-    context 'when registration is not present for current term' do
-      let(:current_term_id) { '2192' }
-      it 'return empty array' do
-        expect(subject.instance_eval { current_term_registrations }).to eq []
-      end
-    end
-    context 'when multiple registrations for current term' do
-      let(:registrations_array) do
+    context 'when single registration for latest term' do
+      let(:highest_registrations_term_id) { '2192' }
+      let(:student_registrations) do
         [
-          {'term' => {'id' => '2182'}, 'academicCareer' => {'code' => 'GRAD'}},
-          {'term' => {'id' => '2182'}, 'academicCareer' => {'code' => 'LAW'}},
           {'term' => {'id' => '2185'}, 'academicCareer' => {'code' => 'GRAD'}},
+          {'term' => {'id' => '2192'}, 'academicCareer' => {'code' => 'GRAD'}},
           {'term' => {'id' => '2188'}, 'academicCareer' => {'code' => 'GRAD'}},
         ]
       end
+      it 'returns the latest registration' do
+        registrations = subject.instance_eval { latest_term_registrations }
+        expect(registrations.count).to eq 1
+        expect(registrations[0]['term']['id']).to eq '2192'
+        expect(registrations[0]['academicCareer']['code']).to eq 'GRAD'
+      end
+    end
+    context 'when multiple registrations for latest term' do
+      let(:highest_registrations_term_id) { '2192' }
+      let(:student_registrations) do
+        [
+          {'term' => {'id' => '2185'}, 'academicCareer' => {'code' => 'GRAD'}},
+          {'term' => {'id' => '2188'}, 'academicCareer' => {'code' => 'GRAD'}},
+          {'term' => {'id' => '2192'}, 'academicCareer' => {'code' => 'GRAD'}},
+          {'term' => {'id' => '2192'}, 'academicCareer' => {'code' => 'LAW'}},
+        ]
+      end
       it 'returns both registrations' do
-        registrations = subject.instance_eval { current_term_registrations }
+        registrations = subject.instance_eval { latest_term_registrations }
         expect(registrations.count).to eq 2
+        expect(registrations[0]['term']['id']).to eq '2192'
+        expect(registrations[1]['term']['id']).to eq '2192'
         expect(registrations[0]['academicCareer']['code']).to eq 'GRAD'
         expect(registrations[1]['academicCareer']['code']).to eq 'LAW'
       end
     end
     context 'when calling more than once' do
       it 'remembers its own response' do
-        expect(Berkeley::Terms).to receive(:fetch).once.and_return(berkeley_terms)
-        expect(subject.instance_eval { current_term_registrations[0]['term']['id'] }).to eq '2182'
-        expect(subject.instance_eval { current_term_registrations[0]['term']['id'] }).to eq '2182'
+        expect(subject).to receive(:student_registrations).twice.and_return(student_registrations)
+        expect(subject.instance_eval { latest_term_registrations[0]['term']['id'] }).to eq '2188'
+        expect(subject.instance_eval { latest_term_registrations[0]['term']['id'] }).to eq '2188'
+      end
+    end
+  end
+
+  describe '#highest_registrations_term_id' do
+    before { allow(subject).to receive(:student_registrations).and_return(student_registrations) }
+    context 'when registrations are not present' do
+      let(:student_registrations) { [] }
+      it 'returns nil' do
+        expect(subject.instance_eval { highest_registrations_term_id }).to eq nil
+      end
+    end
+    context 'when registrations are present' do
+      let(:student_registrations) do
+        [
+          {'academicCareer' => {'code' => 'UGRD'}, 'term' => {'id' => '2152', 'name' => '2015 Spring'}},
+          {'academicCareer' => {'code' => 'GRAD'}, 'term' => {'id' => '2168', 'name' => '2016 Fall'}},
+          {'academicCareer' => {'code' => 'LAW'}, 'term' => {'id' => '2168', 'name' => '2016 Fall'}},
+          {'academicCareer' => {'code' => 'UGRD'}, 'term' => {'id' => '2162', 'name' => '2016 Spring'}},
+          {'academicCareer' => {'code' => 'UGRD'}, 'term' => {'id' => '2158', 'name' => '2015 Fall'}},
+        ]
+      end
+      it 'returns highest term id' do
+        expect(subject.instance_eval { highest_registrations_term_id }).to eq '2168'
       end
     end
   end


### PR DESCRIPTION
https://jira.berkeley.edu/browse/SISRP-39356
https://jira-secure.berkeley.edu/browse/SISRP-39356

Students that are no longer active (discontinued, dismissed, or completed) are not able to see their academic level when they should. This switches to an algorithm that identifies the "latest" term (highest one in a sorted list) and grabs the academic levels for that term. Most cases have a single academic level, but a dual career student (GRAD + LAW) might have two level descriptions that need to be displayed.