### PR TITLE
SISRP-46673 - Updates API request path in Financials proxy

### DIFF
--- a/app/models/financials/proxy.rb
+++ b/app/models/financials/proxy.rb
@@ -60,7 +60,7 @@ module Financials
     end
 
     def request_url
-      "#{@settings.base_url}/student/#{@student_id}"
+      "#{@settings.base_url}/#{@student_id}"
     end
 
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -186,7 +186,7 @@ mailgun_proxy:
 
 financials_proxy:
   fake: false
-  base_url: 'https://apis.berkeley.edu/uat/cfv'
+  base_url: 'https://apis.berkeley.edu/uat/sis/v2/cfv/students'
   app_id: ''
   app_key: ''
 


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/SISRP-46673

This API only has the single end-point for the student, so I don't think we need to keep the base_url short. I'm moving it all to the proxy configuration so that no matter what the URL ends up being, we'll be able to modify the configuration rather than the code.