### PR TITLE
SISRP-45286 - Adds FA Transcript link to FA Summary card

### DIFF
--- a/app/models/financial_aid/my_financial_aid_summary.rb
+++ b/app/models/financial_aid/my_financial_aid_summary.rb
@@ -58,6 +58,7 @@ module FinancialAid
     def links
       {
         financialAidWebsite: fetch_link('UC_CX_FA_UCB_FA_WEBSITE'),
+        financialAidTranscript: fetch_link('UC_CX_FA_FIN_AID_TRANSCRIPT'),
         calStudentCentral: fetch_link('UC_CX_CAL_STUDENT_CENTRAL')
       }
     end

--- a/fixtures/xml/campus_solutions/link_api_multiple.xml
+++ b/fixtures/xml/campus_solutions/link_api_multiple.xml
@@ -2318,4 +2318,21 @@ This link should take an instructor to the Grade Roster in BCS of the identified
     <URL>EMPLOYEE/SA/c/UC_FA_RDC_CNCL_FLU.UC_FA_RDC_CNCL_FLU.GBL?ucInstitution={INSTITUTION}&amp;ucAidYear={AID_YEAR}</URL>
     <COMMENTS/>
   </Link>
+  <Link>
+    <URL_ID>UC_CX_FA_FIN_AID_TRANSCRIPT</URL_ID>
+    <Description>Download Financial Aid Summary Report</Description>
+    <HOVER_OVER_TEXT>Download Financial Aid Summary Report</HOVER_OVER_TEXT>
+    <PROPERTIES type="array">
+      <PROPERTY>
+        <NAME>CALCENTRAL</NAME>
+        <value>FINANCIAL</value>
+      </PROPERTY>
+      <PROPERTY>
+        <NAME>NEW_WINDOW</NAME>
+        <value>Y</value>
+      </PROPERTY>
+    </PROPERTIES>
+    <URL>EMPLOYEE/SA/c/UC_FA_RDC_CNCL_FLU.UC_FA_RDC_CNCL_FLU.GBL?ucInstitution={INSTITUTION}&amp;ucAidYear={AID_YEAR}</URL>
+    <COMMENTS/>
+  </Link>
 </UC_LINK_RESOURCES>

--- a/spec/models/financial_aid/my_financial_aid_summary_spec.rb
+++ b/spec/models/financial_aid/my_financial_aid_summary_spec.rb
@@ -4,6 +4,7 @@ describe FinancialAid::MyFinancialAidSummary do
     allow_any_instance_of(LinkFetcher).to receive(:fetch_link).with('UC_CX_FA_SHOPPING_SHEET', {EMPLID: cs_id, AID_YEAR: '2017', ACAD_CAREER: 'UGRD', INSTITUTION: 'UCB01', SFA_SS_GROUP: 'CCUGRD'}).and_return('2017 shopping sheet link')
     allow_any_instance_of(LinkFetcher).to receive(:fetch_link).with('UC_CX_FA_SHOPPING_SHEET', {EMPLID: cs_id,AID_YEAR: '2018', ACAD_CAREER: 'UGRD', INSTITUTION: 'UCB01', SFA_SS_GROUP: 'CCUGRD'}).and_return('2018 shopping sheet link')
     allow_any_instance_of(LinkFetcher).to receive(:fetch_link).with('UC_CX_FA_UCB_FA_WEBSITE').and_return('financial_aid website link')
+    allow_any_instance_of(LinkFetcher).to receive(:fetch_link).with('UC_CX_FA_FIN_AID_TRANSCRIPT').and_return('financial_aid transcript link')
     allow_any_instance_of(LinkFetcher).to receive(:fetch_link).with('UC_CX_CAL_STUDENT_CENTRAL').and_return('cal student central link')
   end
   let(:aid_years) do
@@ -63,8 +64,9 @@ describe FinancialAid::MyFinancialAidSummary do
     end
     it 'provides the expected links' do
       expect(subject[:financialAidSummary][:links]).to be
-      expect(subject[:financialAidSummary][:links].count).to eq 2
+      expect(subject[:financialAidSummary][:links].count).to eq 3
       expect(subject[:financialAidSummary][:links][:financialAidWebsite]).to eq 'financial_aid website link'
+      expect(subject[:financialAidSummary][:links][:financialAidTranscript]).to eq 'financial_aid transcript link'
       expect(subject[:financialAidSummary][:links][:calStudentCentral]).to eq 'cal student central link'
     end
     it 'does not provide a link to the Shopping Sheet' do

--- a/src/assets/templates/widgets/finaid_summary_footer.html
+++ b/src/assets/templates/widgets/finaid_summary_footer.html
@@ -10,9 +10,18 @@
       data-cc-campus-solutions-link-directive-uc-from-text="true"
     >{{financialAidSummary.selected.shoppingSheetLink.name}}<i class="fa fa-file-text"></i></a>
   </div>
-  <div>
-    <a data-ng-if="financialAidSummary.links.financialAidWebsite.url"
-       data-cc-campus-solutions-link-directive="financialAidSummary.links.financialAidWebsite"
-    ></a>
+  <div data-ng-if="financialAidSummary.links.financialAidTranscript.url">
+    <ul class="cc-list-links">
+      <li><a data-ng-if="financialAidSummary.links.financialAidWebsite.url"
+        data-cc-campus-solutions-link-directive="financialAidSummary.links.financialAidWebsite"
+      ></a></li>
+      <li><a data-ng-if="financialAidSummary.links.financialAidTranscript.url"
+        data-cc-campus-solutions-link-directive="financialAidSummary.links.financialAidTranscript"
+      ></a></li>
+  </div>
+  <div data-ng-if="!financialAidSummary.links.financialAidTranscript.url">
+      <a data-ng-if="financialAidSummary.links.financialAidWebsite.url"
+        data-cc-campus-solutions-link-directive="financialAidSummary.links.financialAidWebsite"
+      ></a>
   </div>
 </div>


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/SISRP-45286
![Screen Shot 2019-07-18 at 4 06 27 PM](https://user-images.githubusercontent.com/12177541/61495561-90145f00-a976-11e9-80d6-397db5b76924.png)

Note - we intend to make the CS Link API value "Inactive" so that this link does not show to the student until the dependent CS work is complete.
