### PR TITLE
SISRP-47626-Missing-Cancel-For-Non-Payment

### DIFF
--- a/src/react/components/_academics/StatusAndHoldsCard/CNPWarning.js
+++ b/src/react/components/_academics/StatusAndHoldsCard/CNPWarning.js
@@ -28,9 +28,9 @@ const propTypes = {
 
 const CNPWarning = ({ registration }) => {
   const iconClass = `cc-icon fa ${iconForSummary(registration)}`;
-  const { showCnp } = registration;
+  const { hasCNPWarning } = registration;
 
-  if (showCnp) {
+  if (hasCNPWarning) {
     const { cnpStatus: { explanation, summary } = {} } = registration;
     return (
       <DisclosureItem>

--- a/src/react/components/_academics/StatusAndHoldsCard/RegistrationPeriod.js
+++ b/src/react/components/_academics/StatusAndHoldsCard/RegistrationPeriod.js
@@ -18,8 +18,8 @@ const RegistrationPeriod = ({ period }) => {
     return (
       <div className="RegistrationPeriod">
         <h4>{ period.semester } { period.year }</h4>
-        <CNPWarning registration={period} />
         <RegistrationStatus {...period.regStatus} />
+        <CNPWarning registration={period} />
         <CalGrantStatusItem acknowledgement={period.calGrantAcknowledgement} />
       </div>
     );


### PR DESCRIPTION
The flag for Cancel-For-Non-Payment should be hasCNPWarning, not showCnp. In addition, CNP warning should come before registration status message.  