### PR TITLE
SISRP-47655 - hides Academic Holds from Finaid Profile card when 0

### DIFF
--- a/app/models/financial_aid/my_finaid_profile.rb
+++ b/app/models/financial_aid/my_finaid_profile.rb
@@ -124,6 +124,17 @@ module FinancialAid
       end
     end
 
+    def acad_holds
+      return nil unless status.try(:[], 'acad_holds').to_i > 0
+      [
+        {
+          title: 'Academic Holds',
+          value: status.try(:[], 'acad_holds')
+        }
+      ]
+    end
+
+
     def itemGroupsProfile
       @itemGroupsProfile ||= [
         [
@@ -158,12 +169,7 @@ module FinancialAid
             value: status.try(:[], 'filing_fee')
           }
         ],
-        [
-          {
-            title: 'Academic Holds',
-            value: status.try(:[], 'acad_holds')
-          }
-        ],
+        acad_holds,
         [
           {
             title: 'SAP Status',

--- a/spec/models/financial_aid/my_finaid_profile_spec.rb
+++ b/spec/models/financial_aid/my_finaid_profile_spec.rb
@@ -35,8 +35,6 @@ describe FinancialAid::MyFinaidProfile do
       expect(subject[:finaidProfile][:itemGroups][2][0][:value]).to eq nil
       expect(subject[:finaidProfile][:itemGroups][2][1][:title]).to eq 'Filing Fee Status'
       expect(subject[:finaidProfile][:itemGroups][2][1][:value]).to eq nil
-      expect(subject[:finaidProfile][:itemGroups][3][0][:title]).to eq 'Academic Holds'
-      expect(subject[:finaidProfile][:itemGroups][3][0][:value]).to eq '0'
       expect(subject[:finaidProfile][:itemGroups][4][0][:title]).to eq 'SAP Status'
       expect(subject[:finaidProfile][:itemGroups][4][0][:value]).to eq 'Meeting Satis Acad Progress'
       expect(subject[:finaidProfile][:itemGroups][4][1][:title]).to eq 'Award Status'
@@ -104,8 +102,6 @@ describe FinancialAid::MyFinaidProfile do
         expect(subject[:finaidProfile][:itemGroups][2][0][:value]).to eq nil
         expect(subject[:finaidProfile][:itemGroups][2][1][:title]).to eq 'Filing Fee Status'
         expect(subject[:finaidProfile][:itemGroups][2][1][:value]).to eq nil
-        expect(subject[:finaidProfile][:itemGroups][3][0][:title]).to eq 'Academic Holds'
-        expect(subject[:finaidProfile][:itemGroups][3][0][:value]).to eq '0'
         expect(subject[:finaidProfile][:itemGroups][4][0][:title]).to eq 'SAP Status'
         expect(subject[:finaidProfile][:itemGroups][4][0][:value]).to eq 'Meeting Satis Acad Progress'
         expect(subject[:finaidProfile][:itemGroups][4][1][:title]).to eq 'Award Status'


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/SISRP-47655