### PR TITLE
SISRP-46050 - Sets MyAcademics::MyAcademicsStatus to use 15 minute cache expiration

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -242,6 +242,7 @@ cache:
     failure: <%= 30.seconds %>
     BackgroundJobsCheck: <%= 29.days %>
     MyAcademics::Merged: <%= 15.minutes %>
+    MyAcademics::MyAcademicStatus: <%= 15.minutes %>
     MyActivities::Merged: <%= 10.minutes %>
     MyBadges::Merged: <%= 2.hours %>
     MyCampusLinksController: NEXT_08_00


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/SISRP-46050

MyAcademics::Merged relies on iHub data from MyAcademicsStatus data. Need GPA data to line up with grading data. Setting both to expire after 15 minutes.