### PR TITLE
SISRP-46547 Et al.: Only show undergrad reg status in popover if warning

### DIFF
--- a/app/models/user/academics/status/undergraduate.rb
+++ b/app/models/user/academics/status/undergraduate.rb
@@ -31,7 +31,7 @@ module User
         end
 
         def in_popover?
-          true unless message == MSG_NONE
+          [SEVERITY_WARNING].include?(severity)
         end
 
         def badge_count


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/SISRP-46547