### PR TITLE
SISRP-48567 - My Academics Page is missing instructor assignments for faculty

### DIFF
--- a/app/models/my_academics/semesters.rb
+++ b/app/models/my_academics/semesters.rb
@@ -166,7 +166,7 @@ module MyAcademics
     end
 
     def filter_enrollments(enrollment_term)
-      enrollment_term.delete_if do |enrollment|
+      enrollment_term.reject do |enrollment|
         enrollment[:role] != 'Student' || exclude_enrollment_for_law?(enrollment)
       end
     end


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/SISRP-48567

This was a very silly thing that happened that was hard to diagnose. The MyAcademics::Semesters class was deleting items from an array, and this was going all the way back to the cached data returned by `EdoOracle::UserCourses::All#all_campus_courses`. Because MyAcademics::Teaching relies on the same data, no instructor courses were showing because the non-student courses were all deleted in MyAcademics::Semester.

This fix resolves that.