### PR TITLE
NOJIRA: Allow build server access to devDependencies

### DIFF
--- a/script/front-end-build.sh
+++ b/script/front-end-build.sh
@@ -8,7 +8,7 @@ fi
 
 echo "Node version: $(node --version)"
 npm config set strict-ssl false
-npm install --production || { echo "ERROR: npm install failed" ; exit 1 ; }
+npm install || { echo "ERROR: npm install failed" ; exit 1 ; }
 
 # Build and fingerprint front-end assets.
 npm run build || { echo "ERROR: npm front-end assets build failed" ; exit 1 ; }


### PR DESCRIPTION
Allows us to make a clear distinction between libraries the app uses and those required for local development, building, linting, etc. by allowing our build server access everything.