### PR TITLE
SISRP-48130 - Allow APR Link to Remain Active after Students' Last Day of Term for Expected Grad Term

### DIFF
--- a/app/models/degree_progress/my_undergrad_requirements.rb
+++ b/app/models/degree_progress/my_undergrad_requirements.rb
@@ -31,15 +31,15 @@ module DegreeProgress
 
     def get_incomplete_programs_roles
       ugrd_statuses = MyAcademics::MyAcademicStatus.statuses_by_career_role(@uid, ['ugrd'])
-      return [] if ugrd_statuses.empty?
+      return [] if ugrd_statuses.blank?
 
       plans = incomplete_plans_from_statuses(ugrd_statuses)
-      return [] if plans.empty?
+      return [] if plans.blank?
 
       plans.map do |plan|
         program = plan.try(:[], 'academicPlan').try(:[], 'academicProgram').try(:[], 'program')
         program.try(:[], 'code')
-      end.uniq
+      end.uniq.compact
     end
 
     def should_see_links?

--- a/spec/models/degree_progress/my_undergrad_requirements_spec.rb
+++ b/spec/models/degree_progress/my_undergrad_requirements_spec.rb
@@ -236,4 +236,71 @@ describe DegreeProgress::MyUndergradRequirements do
     end
   end
 
+  describe '#get_incomplete_programs_roles' do
+    let(:result) { subject.get_incomplete_programs_roles }
+    before do
+      allow(MyAcademics::MyAcademicStatus).to receive(:statuses_by_career_role).with(user_id, ['ugrd']).and_return(academic_statuses)
+    end
+    let(:academic_statuses) do
+      [
+        {
+          'studentPlans' => [
+            {
+              'academicPlan'=> {
+                'academicProgram'=> {
+                  'program'=> {
+                    'code'=> ugrd_role
+                  }
+                }
+              },
+              'statusInPlan'=> {
+                'status'=> {
+                  'code'=> ugrd_program_status_code
+                }
+              }
+            }
+          ]
+        }
+      ]
+    end
+    let(:ugrd_role) { 'XXXX' }
+    let(:ugrd_program_status_code) { 'CM' }
+    context 'when no academic statuses are returned' do
+      let(:academic_statuses) { nil }
+      it 'returns []' do
+        expect(result).to eq []
+      end
+    end
+    context 'when academic statuses returns incomplete data' do
+      let(:academic_statuses) do
+        [
+          {
+            'studentPlans' => [
+              {
+                'primary'=> false
+              }
+            ]
+          }
+        ]
+      end
+      it 'returns []' do
+        expect(result).to eq []
+      end
+    end
+    context 'when academic statuses returned valid but completed program' do
+      let(:ugrd_role) { 'UCED' }
+      let(:ugrd_program_status_code) { 'CM' }
+      it 'returns []' do
+        expect(result).to eq []
+      end
+    end
+    context 'when academic statuses returned valid program' do
+      let(:ugrd_role) { 'UCED' }
+      let(:ugrd_program_status_code) { 'AC' }
+      it 'returns valid program role' do
+        expect(result).to eq ['UCED']
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/SISRP-48130
* fix edge case of missing statuses for advisors 
* added more unit tests to cover edge cases 