### PR TITLE
SISRP-46663 pass the original deposit due to the html/angular

### DIFF
--- a/app/models/campus_solutions/sir/sir_statuses.rb
+++ b/app/models/campus_solutions/sir/sir_statuses.rb
@@ -135,12 +135,13 @@ module CampusSolutions
       def add_deposit_info(sir_checklist_items)
         sir_checklist_items.each do |item|
           deposit = { required: false }
+          application_nbr = item[:checkListMgmtAdmp].try(:[], :admApplNbr).try(:to_s)
+          deposit_info = unpack_deposit_response MyDeposit.new(@uid, adm_appl_nbr: application_nbr).get_feed
           if is_incomplete? item
-            application_nbr = item[:checkListMgmtAdmp].try(:[], :admApplNbr).try(:to_s)
-            deposit_info = unpack_deposit_response MyDeposit.new(@uid, adm_appl_nbr: application_nbr).get_feed
             deposit.merge!(deposit_info)
             deposit[:required] = deposit_due? deposit[:dueAmt]
           end
+          deposit[:origDepositDue] = deposit_info[:origDepositDue]
           item[:deposit] = deposit
         end
         add_undergraduate_new_admit_attributes(sir_checklist_items)


### PR DESCRIPTION
SISRP-46663 Confirming Deposit Waivers, before and after SIR (CLC DEV)

@redconfetti, Instead of mapping origDepositDue to "Waived", I decided to pass the origDepositDue to the HTML/angular code. It gives the front end the flexibility to show different messages depending on the amount, in case the business requirement changes in the future. 