### PR TITLE
SISRP-51360 - Higher Degree Committees card is taking long time to load

### DIFF
--- a/config/settings.yml
+++ b/config/settings.yml
@@ -303,6 +303,7 @@ cache:
     CampusSolutions::DashboardUrl: <%= 29.days %>
 
     CalnetCrosswalk::ByUid: <%= 4.hours %>
+    CalnetCrosswalk::ByCsId: <%= 4.hours %>
     User::Identifiers::Cached: <%= 4.hours %>
 
     # Merge of independently cached feeds.


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/SISRP-51360

The Graduate Higher Degree Commmittees card relies on conversion of EMPLID to UID for each committee member. We're cacheing the results of the Crosswalk lookup, but only for 35 minutes. We're cacheing the opposite lookup (UID to EMPLID) for 4 hours, so I don't see why it wouldn't be appropriate to cache the reverse lookup for 4 hours also.