### PR TITLE
SISRP-50112: Create link from Student Overview page in CalCentral to BOA

### DIFF
--- a/src/assets/templates/widgets/toolbox/user_preview.html
+++ b/src/assets/templates/widgets/toolbox/user_preview.html
@@ -47,9 +47,9 @@
                   <i class="fa fa-user cc-icon-curious-blue cc-profile-view-link-left-margin"></i>
                   <a
                     class="cc-profile-view-link-indent cc-profile-view-link-left-margin"
-                    data-ng-href="https://boa.berkeley.edu/student/{{targetUser.campusSolutionsId}}"
+                    data-ng-href="https://boa.berkeley.edu/student/{{targetUser.ldapUid}}"
                     data-ng-click="api.analytics.trackExternalLink('Personal Summary', 'Link to BOA',
-                     'https://boa.berkeley.edu/student/{{targetUser.campusSolutionsId}}')"
+                     'https://boa.berkeley.edu/student/{{targetUser.ldapUid}}')"
                     title="View Student in BOA"
                     >View in BOA</a
                   >


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/SISRP-50112
Create link from Student Overview page in CalCentral to BOA (CLC dev)

should pass UID, not student ID to BOA (Berkeley Online Adivising)