### PR TITLE
SISRP-51938 - Instructors cannot see Grade Basis and Units in Class Roster

### DIFF
--- a/app/models/berkeley/grade_options.rb
+++ b/app/models/berkeley/grade_options.rb
@@ -13,6 +13,8 @@ module Berkeley
           'Law'
         when 'EPN', 'PNP'
           'P/NP'
+        when 'DPN'
+          'Default P/NP'
         when 'ESU', 'SUS'
           'S/U'
         when 'CNC'


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/SISRP-51938