### PR TITLE
SISRP-53041 - UGRD Students with S09 SIs and enrollment are not seeing the You are Subject to Cancel for Non-Payment Message in Status and Holds Card

### DIFF
--- a/app/models/user/academics/term_registration.rb
+++ b/app/models/user/academics/term_registration.rb
@@ -133,7 +133,9 @@ module User
         # This needs to use the same logic for showCNP flag used for semester
         # CNP statuses. We need to call RegistrationsModule.show_cnp?(term)
         # TODO: merge semesters CNP logic with status and hold card
-         MyRegistrations::RegistrationsModule.show_cnp?(@term)
+          JSON.parse(MyRegistrations::Statuses.new(user.uid).get_feed)['registrations'][term_id]['showCnp']
+      rescue NoMethodError
+          false
       end
 
       def cnp_status


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/SISRP-53041

I could not easily access the registrations from the model directly so I had to call cached feed and parse json, ugly but at least cnp logic in unified. This whole thing needs to be refactored and the registration_module retired