### PR TITLE
SISRP-53041 - UGRD Students with S09 SIs and enrollment are not seeing the You are Subject to Cancel for Non-Payment Message in Status and Holds Card

### DIFF
--- a/app/models/user/academics/term_registration.rb
+++ b/app/models/user/academics/term_registration.rb
@@ -139,7 +139,11 @@ module User
       end
 
       def cnp_status
-        @cnp_status ||=  User::Academics::Status::CancellationForNonPayment.new(self)
+       @cnp_status ||= if show_cnp?
+          User::Academics::Status::CancellationForNonPayment.new(self)
+        else
+          null_status
+        end
       end
 
       def null_status


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/SISRP-53041

@developish , turns out we need to set null_status to ensure popover counts and behavior match visibility in status and holds 