### PR TITLE
SISRP-52459: Fix class notes link displaying for law instructors

### DIFF
--- a/src/react/components/_academics/ClassInformationCard/ClassAttributesTable.js
+++ b/src/react/components/_academics/ClassInformationCard/ClassAttributesTable.js
@@ -53,9 +53,10 @@ export default function ClassAttributesTable({
   slug,
   sections,
   isInstructor,
+  isLaw,
 }) {
   const primarySection = sections.find(section => section.is_primary_section);
-  const { grading: { gradingBasis } = {}, isLaw } = primarySection;
+  const { grading: { gradingBasis } = {} } = primarySection;
   const academicGuide = classNotesLink(semesterSlug, slug, primarySection);
 
   const orientation = tableOrientation({

--- a/src/react/components/_academics/ClassInformationCard/ClassInformationCard.js
+++ b/src/react/components/_academics/ClassInformationCard/ClassInformationCard.js
@@ -19,7 +19,6 @@ export default function ClassInformationCard({
   course: {
     title,
     units,
-    isLaw,
     role,
     gradingBasis,
     classNotesLink,
@@ -27,6 +26,7 @@ export default function ClassInformationCard({
     semesterSlug,
     slug,
     listings,
+    courseCareerCode,
   },
 }) {
   return (
@@ -45,7 +45,7 @@ export default function ClassInformationCard({
         units={units}
         gradingBasis={gradingBasis}
         classNotesLink={classNotesLink}
-        isLaw={isLaw}
+        isLaw={courseCareerCode === 'LAW'}
         semesterSlug={semesterSlug}
         slug={slug}
         isInstructor={isInstructor}
@@ -86,5 +86,6 @@ ClassInformationCard.propTypes = {
     semesterSlug: PropTypes.string,
     slug: PropTypes.string,
     listings: PropTypes.array,
+    courseCareerCode: PropTypes.string,
   }),
 };


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/SISRP-52459

`teachingSemesters` don't have the `isLaw` attribute, but they share the `courseCareerCode` with regular student semesters