### PR TITLE
SISRP-53539: Allow ENF::Handler classes to work with any existing ENF payload format

### DIFF
--- a/app/models/enf/handler.rb
+++ b/app/models/enf/handler.rb
@@ -10,8 +10,8 @@ module ENF
       self.message = message
     end
 
-    def uid
-      message.student_uid
+    def uids
+      message.student_uids
     end
   end
 end

--- a/app/models/enf/message.rb
+++ b/app/models/enf/message.rb
@@ -5,13 +5,10 @@ module ENF
     attr_accessor :timestamp
     attr_accessor :text
 
-    def student_uid
-      @student_uid ||= User::Current.from_campus_solutions_id(student_campus_solutions_id).uid
-    end
-
-    def student_campus_solutions_id
-      student['StudentId']
-    rescue NoMethodError
+    def student_uids
+      student_ids.collect do |id|
+        User::Current.from_campus_solutions_id(id).uid
+      end
     end
 
     def topic
@@ -38,6 +35,19 @@ module ENF
     def student
       payload['student']
     rescue NoMethodError
+    end
+
+    def students
+      payload['students']
+    rescue NoMethodError
+    end
+
+    def student_ids
+      if students
+        Array(students['id'])
+      elsif student
+        Array(student['StudentId'])
+      end
     end
   end
 end

--- a/app/models/user/cards/enrollment_expiry.rb
+++ b/app/models/user/cards/enrollment_expiry.rb
@@ -9,13 +9,15 @@ module User
       end
 
       def expire
-        ::MyAcademics::ClassEnrollments.expire(uid)
-        ::MyAcademics::MyHolds.expire(uid)
-        ::MyAcademics::MyAcademicStatus.expire(uid)
+        uids.each do |uid|
+          ::MyAcademics::ClassEnrollments.expire(uid)
+          ::MyAcademics::MyHolds.expire(uid)
+          ::MyAcademics::MyAcademicStatus.expire(uid)
 
-        ::HubEdos::StudentApi::V2::Feeds::Registrations.expire(uid)
-        ::HubEdos::StudentApi::V2::Feeds::StudentAttributes.expire(uid)
-        ::HubEdos::StudentApi::V2::Feeds::AcademicStatuses.expire(uid)
+          ::HubEdos::StudentApi::V2::Feeds::Registrations.expire(uid)
+          ::HubEdos::StudentApi::V2::Feeds::StudentAttributes.expire(uid)
+          ::HubEdos::StudentApi::V2::Feeds::AcademicStatuses.expire(uid)
+        end
       end
     end
   end

--- a/app/models/user/notifications/expiry.rb
+++ b/app/models/user/notifications/expiry.rb
@@ -1,10 +1,16 @@
 module User
   module Notifications
-    class Expiry
+    class Expiry < ::ENF::Handler
       ENF::Processor.instance.register("sis:student:messages", self)
 
       def self.call(message)
-        ::User::Notifications::CachedFeed.expire(message.student_uid)
+        self.new(message).expire
+      end
+
+      def expire
+        uids.each do |uid|
+          ::User::Notifications::CachedFeed.expire(uid)
+        end
       end
     end
   end

--- a/app/models/user/tasks/expiry.rb
+++ b/app/models/user/tasks/expiry.rb
@@ -9,17 +9,19 @@ module User
       end
 
       def expire
-        ::CampusSolutions::MyChecklist.expire(uid)
-        ::MyTasks::Merged.expire(uid)
-        ::CampusSolutions::Sir::SirStatuses.expire(uid)
+        uids.each do |uid|
+          ::CampusSolutions::MyChecklist.expire(uid)
+          ::MyTasks::Merged.expire(uid)
+          ::CampusSolutions::Sir::SirStatuses.expire(uid)
 
-        ::User::Tasks::AgreementsFeed.expire(uid)
-        ::User::Tasks::ChecklistFeed.expire(uid)
-        ::MyAcademics::MyHolds.expire(uid)
-        ::MyAcademics::MyAcademicStatus.expire(uid)
-        ::MyAcademics::ClassEnrollments.expire(uid)
-        ::FinancialAid::MyFinaidProfile.expire(uid)
-        ::MyActivities::Merged.expire(uid)
+          ::User::Tasks::AgreementsFeed.expire(uid)
+          ::User::Tasks::ChecklistFeed.expire(uid)
+          ::MyAcademics::MyHolds.expire(uid)
+          ::MyAcademics::MyAcademicStatus.expire(uid)
+          ::MyAcademics::ClassEnrollments.expire(uid)
+          ::FinancialAid::MyFinaidProfile.expire(uid)
+          ::MyActivities::Merged.expire(uid)
+        end
       end
     end
   end

--- a/spec/models/enf/message_spec.rb
+++ b/spec/models/enf/message_spec.rb
@@ -1,26 +1,75 @@
-describe ENF::Message do
-  let(:message) {
-    JMSMessageFactory.new('sis:student:messages', {
-      student: {
-        StudentId: campus_solutions_id
-      }
-    })
-  }
+require_relative "./jms_message_factory"
 
+describe ENF::Message do
   let(:campus_solutions_id) { 11111 }
   let(:uid) { 99999 }
 
   subject { described_class.new(message.to_h) }
 
-  it "extracts the topic from the JMS message" do
-    expect(subject.topic).to eq('sis:student:messages')
+  describe "studentId format" do
+    let(:message) {
+      JMSMessageFactory.new('sis:student:messages', {
+        student: {
+          StudentId: campus_solutions_id
+        }
+      })
+    }
+
+    it "extracts the topic from the JMS message" do
+      expect(subject.topic).to eq('sis:student:messages')
+    end
+
+    it "looks up the UID from the Campus Solutions ID" do
+      current_user = double(User::Current)
+      expect(current_user).to receive(:uid).and_return(uid)
+      expect(User::Current).to receive(:from_campus_solutions_id).with(campus_solutions_id).and_return(current_user)
+
+      expect(subject.student_uids).to eq([99999])
+    end
   end
 
-  it "looks up the UID from the Campus Solutions ID" do
-    current_user = double(User::Current)
-    expect(current_user).to receive(:uid).and_return(uid)
-    expect(User::Current).to receive(:from_campus_solutions_id).with(campus_solutions_id).and_return(current_user)
+  describe "batch format" do
+    describe "with a single Campus Solutions ID" do
+      let(:message) {
+        JMSMessageFactory.new('sis:student:messages', {
+          students: {
+            id: campus_solutions_id
+          }
+        })
+      }
 
-    expect(subject.student_uid).to eq(99999)
+      it "looks up the UID from the Campus Solutions ID" do
+        current_user = double(User::Current)
+        expect(current_user).to receive(:uid).and_return(uid)
+        expect(User::Current).to receive(:from_campus_solutions_id).with(campus_solutions_id).and_return(current_user)
+
+        expect(subject.student_uids).to eq([99999])
+      end
+    end
+
+    describe "with multiple Campus Solutions IDs" do
+      let(:campus_solutions_id_one) { 11111 }
+      let(:campus_solutions_id_two) { 22222 }
+
+      let(:message) {
+        JMSMessageFactory.new('sis:student:messages', {
+          students: {
+            id: [campus_solutions_id_one, campus_solutions_id_two]
+          }
+        })
+      }
+
+      it "looks up the UIDs from the Campus Solutions IDs" do
+        user_one = double(User::Current)
+        expect(user_one).to receive(:uid).and_return(99999)
+        user_two = double(User::Current)
+        expect(user_two).to receive(:uid).and_return(88888)
+
+        expect(User::Current).to receive(:from_campus_solutions_id).with(campus_solutions_id_one).and_return(user_one)
+        expect(User::Current).to receive(:from_campus_solutions_id).with(campus_solutions_id_two).and_return(user_two)
+
+        expect(subject.student_uids).to eq([99999, 88888])
+      end
+    end
   end
 end

--- a/spec/models/enf/processor_spec.rb
+++ b/spec/models/enf/processor_spec.rb
@@ -3,12 +3,14 @@ require_relative './jms_message_factory'
 describe ENF::Processor do
   class FakeStudentIDHandler
     def self.call(message)
-      message.student_id
+      message.student_uids
     end
   end
 
   subject { described_class.instance }
-  after(:each) { subject.reset }
+
+  before(:each) { subject.reset }
+
   let(:messages_topic) { 'sis:student:messages' }
   let(:checklist_topic) { 'sis:student:checklist' }
   let(:student_id) { 1234 }
@@ -23,14 +25,14 @@ describe ENF::Processor do
 
   it "dispatches incoming JMS messages to the registered handler" do
     subject.register(messages_topic, FakeStudentIDHandler)
-    expect_any_instance_of(ENF::Message).to receive(:student_id).and_return(student_id)
+    expect_any_instance_of(ENF::Message).to receive(:student_uids).and_return([student_id])
 
     subject.handle(JMSMessageFactory.new(messages_topic, message_payload).to_h)
   end
 
   it "doesn't dispatch messages to other topics" do
     described_class.instance.register(messages_topic, FakeStudentIDHandler)
-    expect_any_instance_of(ENF::Message).not_to receive(:student_id)
+    expect_any_instance_of(ENF::Message).not_to receive(:student_uids)
 
     subject.handle(JMSMessageFactory.new(checklist_topic, message_payload).to_h)
   end


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/SISRP-53539