### PR TITLE
SISRP-54017 - CLC: Divide by Zero error causing error with FA Loan History card

### DIFF
--- a/app/models/concerns/loan_history_module.rb
+++ b/app/models/concerns/loan_history_module.rb
@@ -3,10 +3,10 @@ module Concerns
     extend self
 
     def calculate_estimated_monthly_payment(annual_interest_rate, principal_value, repayment_period)
-      return nil unless annual_interest_rate && principal_value && repayment_period && (annual_interest_rate > 0)
-      annual_interest = (annual_interest_rate / 100)
+      return nil unless annual_interest_rate && principal_value && repayment_period && (annual_interest_rate > 0) && (principal_value > 0)
+      annual_interest = (annual_interest_rate.to_f / 100)
       monthly_interest = annual_interest / 12
-      (monthly_interest * principal_value) / (1 - (1 + monthly_interest)**(-repayment_period))
+      (monthly_interest * principal_value.to_f) / (1 - (1 + monthly_interest)**(-repayment_period.to_f))
     end
 
     def choose_monthly_payment(estimated, minimum, total_amount_owed)

--- a/spec/models/concerns/loan_history_module_spec.rb
+++ b/spec/models/concerns/loan_history_module_spec.rb
@@ -1,0 +1,34 @@
+describe Concerns::LoanHistoryModule do
+  describe '.calculate_estimated_monthly_payment' do
+    let(:annual_interest_rate) { 5 }
+    let(:principal_value) { 2000 }
+    let(:repayment_period) { 120 }
+    let(:result) do
+      described_class.calculate_estimated_monthly_payment(annual_interest_rate, principal_value, repayment_period)
+    end
+    context 'when principal value is zero' do
+      let(:principal_value) { 0 }
+      it 'returns returns nil' do
+        expect(result).to eq nil
+      end
+    end
+    context 'when principal value is not zero' do
+      let(:principal_value) { 2567 }
+      it 'returns estimated monthly payment' do
+        expect(result).to eq 27.227017761870687
+      end
+    end
+    context 'when annual interest rate is a float' do
+      let(:annual_interest_rate) { BigDecimal.new('4.45') }
+      it 'returns value' do
+        expect(result).to eq 20.679511250615757
+      end
+    end
+    context 'when annual interest rate is zero' do
+      let(:annual_interest_rate) { 0 }
+      it 'returns nil' do
+        expect(result).to eq nil
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/SISRP-54017